### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   gitleaks:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Potential fix for [https://github.com/trendmicro/adk-agui-middleware/security/code-scanning/1](https://github.com/trendmicro/adk-agui-middleware/security/code-scanning/1)

The best way to fix this problem is to explicitly set the `permissions` block in the workflow, to restrict the GITHUB_TOKEN to the least required privileges. In this workflow’s case, the steps are: checking out the repo and running a scan. Neither require the ability to write to the repo, but checkout does need read access to `contents`. Thus, we can set `permissions: contents: read` at the job level (inside `jobs.gitleaks:`), or at the top level (affecting all jobs). Since this workflow only defines one job, adding it at the job level is precise and preferred.

To implement this, edit `.github/workflows/gitleaks.yml`. Add the following block under jobs.gitleaks (i.e., line 11), before `runs-on:`:

```yaml
permissions:
  contents: read
```

No new imports, packages, or method definitions are required for this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
