### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,4 +1,6 @@
 name: Semgrep Security Scan
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/trendmicro/adk-agui-middleware/security/code-scanning/2](https://github.com/trendmicro/adk-agui-middleware/security/code-scanning/2)

To fix the problem, we should explicitly specify a minimal `permissions:` block for the workflow or for the jobs within the workflow. The most robust way is to add a top-level `permissions` block, which will apply to all jobs unless a specific job overrides it. Since this workflow's jobs primarily read repository contents and upload scan results (using official actions), the recommended minimal starting point is `contents: read`, which prevents unnecessary write access. If any further permissions are needed in future, they can be added granularly.

This change is best implemented by adding the following block immediately after the workflow's `name` declaration at the top of `.github/workflows/semgrep.yml`:
```
permissions:
  contents: read
```
No new imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
